### PR TITLE
Implement minimal Confluence OpenAPI server

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,10 +23,10 @@ Set the following environment variables (for example in a `.env` file):
 After installing, launch the server with the bundled CLI:
 
 ```bash
-confluence-openapi-tool --host 0.0.0.0 --port 8000
+confluence-openapi-tool --host 0.0.0.0 --port 8123
 ```
 
-Navigate to `http://localhost:8000/docs` to explore the API.
+Navigate to `http://localhost:8123/docs` to explore the API.
 
 ## Docker
 
@@ -40,7 +40,7 @@ docker build -t confluence-openapi-tool \
 Run the container with your environment variables:
 
 ```bash
-docker run --env-file .env -p 8000:8000 confluence-openapi-tool
+docker run --env-file .env -p 8123:8123 confluence-openapi-tool
 ```
 
 > **Warning**

--- a/confluence_openapi_tool/__init__.py
+++ b/confluence_openapi_tool/__init__.py
@@ -1,0 +1,3 @@
+from .server import create_app
+
+__all__ = ["create_app"]

--- a/confluence_openapi_tool/__main__.py
+++ b/confluence_openapi_tool/__main__.py
@@ -1,0 +1,4 @@
+from .cli import main
+
+if __name__ == "__main__":
+    main()

--- a/confluence_openapi_tool/cli.py
+++ b/confluence_openapi_tool/cli.py
@@ -1,0 +1,15 @@
+import uvicorn
+import typer
+
+
+def main(host: str = "127.0.0.1", port: int = 8123) -> None:
+    """Start Confluence OpenAPI Tool server."""
+    uvicorn.run("confluence_openapi_tool.server:create_app", host=host, port=port, factory=True)
+
+
+def entrypoint() -> None:
+    typer.run(main)
+
+
+if __name__ == "__main__":
+    entrypoint()

--- a/confluence_openapi_tool/server.py
+++ b/confluence_openapi_tool/server.py
@@ -1,0 +1,114 @@
+from __future__ import annotations
+
+import os
+from typing import Optional
+
+from fastapi import FastAPI, HTTPException
+from fastapi.middleware.cors import CORSMiddleware
+from pydantic import BaseModel
+import httpx
+
+
+class Settings(BaseModel):
+    url: str
+    username: str
+    token: str
+    space_key: str
+    parent_page: Optional[str] = None
+    allowed_origins: Optional[str] = "*"
+
+
+def load_settings() -> Settings:
+    try:
+        return Settings(
+            url=os.environ["CONFLUENCE_URL"],
+            username=os.environ["CONFLUENCE_USERNAME"],
+            token=os.environ["CONFLUENCE_TOKEN"],
+            space_key=os.environ["CONFLUENCE_SPACE_KEY"],
+            parent_page=os.getenv("CONFLUENCE_PARENT_PAGE"),
+            allowed_origins=os.getenv("ALLOWED_ORIGINS", "*")
+        )
+    except KeyError as exc:
+        missing = exc.args[0]
+        raise RuntimeError(f"Missing required environment variable: {missing}")
+
+
+class PageCreate(BaseModel):
+    title: str
+    body: str
+
+
+class PageUpdate(BaseModel):
+    title: Optional[str] = None
+    body: Optional[str] = None
+
+
+def create_app() -> FastAPI:
+    settings = load_settings()
+    app = FastAPI(title="Confluence OpenAPI Tool")
+
+    app.add_middleware(
+        CORSMiddleware,
+        allow_origins=[settings.allowed_origins] if settings.allowed_origins != "*" else ["*"],
+        allow_credentials=True,
+        allow_methods=["*"],
+        allow_headers=["*"],
+    )
+
+    async def get_client() -> httpx.AsyncClient:
+        auth = (settings.username, settings.token)
+        return httpx.AsyncClient(auth=auth, base_url=settings.url.rstrip("/") + "/wiki/rest/api")
+
+    @app.get("/pages/{page_id}")
+    async def get_page(page_id: str):
+        async with await get_client() as client:
+            resp = await client.get(f"/content/{page_id}", params={"expand": "body.storage,version"})
+            if resp.status_code >= 400:
+                raise HTTPException(status_code=resp.status_code, detail=resp.text)
+            return resp.json()
+
+    @app.get("/pages")
+    async def list_pages(limit: int = 25):
+        async with await get_client() as client:
+            resp = await client.get("/content", params={"type": "page", "spaceKey": settings.space_key, "limit": limit})
+            if resp.status_code >= 400:
+                raise HTTPException(status_code=resp.status_code, detail=resp.text)
+            return resp.json()
+
+    @app.post("/pages")
+    async def create_page(page: PageCreate):
+        payload = {
+            "type": "page",
+            "title": page.title,
+            "space": {"key": settings.space_key},
+            "body": {"storage": {"value": page.body, "representation": "storage"}},
+        }
+        if settings.parent_page:
+            payload["ancestors"] = [{"id": settings.parent_page}]
+        async with await get_client() as client:
+            resp = await client.post("/content", json=payload)
+            if resp.status_code >= 400:
+                raise HTTPException(status_code=resp.status_code, detail=resp.text)
+            return resp.json()
+
+    @app.put("/pages/{page_id}")
+    async def update_page(page_id: str, update: PageUpdate):
+        async with await get_client() as client:
+            current = await client.get(f"/content/{page_id}", params={"expand": "version"})
+            if current.status_code >= 400:
+                raise HTTPException(status_code=current.status_code, detail=current.text)
+            data = current.json()
+            version = data["version"]["number"] + 1
+            payload = {
+                "id": page_id,
+                "type": "page",
+                "title": update.title or data["title"],
+                "version": {"number": version},
+                "body": {"storage": {"value": update.body or data.get("body", {}).get("storage", {}).get("value", ""), "representation": "storage"}}
+            }
+            resp = await client.put(f"/content/{page_id}", json=payload)
+            if resp.status_code >= 400:
+                raise HTTPException(status_code=resp.status_code, detail=resp.text)
+            return resp.json()
+
+    return app

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,21 @@
+[build-system]
+requires = ["setuptools>=61"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "confluence-openapi-tool"
+version = "0.1.0"
+description = "Minimal FastAPI wrapper for Confluence Cloud"
+authors = [{name = "Wenlin-AI"}]
+readme = "README.md"
+requires-python = ">=3.10"
+dependencies = [
+    "fastapi",
+    "uvicorn",
+    "httpx",
+    "python-dotenv",
+    "typer",
+]
+
+[project.scripts]
+confluence-openapi-tool = "confluence_openapi_tool.cli:entrypoint"


### PR DESCRIPTION
## Summary
- add `pyproject.toml` with FastAPI dependencies and console script
- implement `create_app` FastAPI factory with CRUD endpoints
- provide CLI wrapper using Typer and Uvicorn
- expose CLI entrypoint via package
- update default port to 8123 in CLI and docs

## Testing
- `pip install -e .`
- `confluence-openapi-tool --help`
- `CONFLUENCE_URL=https://example.atlassian.net CONFLUENCE_USERNAME=foo CONFLUENCE_TOKEN=bar CONFLUENCE_SPACE_KEY=ABC confluence-openapi-tool --port 8123 --host 127.0.0.1 & pid=$!; sleep 2; kill $pid; wait $pid 2>/dev/null`

------
https://chatgpt.com/codex/tasks/task_e_68528013f6b4832b9f7c597d488b90b5